### PR TITLE
Add feature of CRUD of upcoming perahera for admins and organizers

### DIFF
--- a/app/Http/Controllers/PeraheraController.php
+++ b/app/Http/Controllers/PeraheraController.php
@@ -2,15 +2,23 @@
 
 namespace App\Http\Controllers;
 
+use Carbon\Carbon;
 use App\Models\Perahera;
 use Illuminate\Http\Request;
+use App\Http\Resources\PeraheraResource;
 
 class PeraheraController extends Controller
 {
     public function index()
     {
         // anyone can view list of upcoming peraheras
-        return Perahera::with('user')->latest()->get();
+        $peraheras = Perahera::with('user')
+            ->where('status', 'active')
+            ->whereDate('start_date', '>=', now()->toDateString())
+            ->orderBy('start_date')
+            ->paginate(20);
+
+        return PeraheraResource::collection($peraheras);
     }
 
     public function store(Request $request)
@@ -24,17 +32,35 @@ class PeraheraController extends Controller
         $data = $request->validate([
             'name'        => ['required','string','max:255'],
             'description' => ['nullable','string'],
-            'start_date'  => ['required','date'],
-            'end_date'    => ['required','date','after_or_equal:start_date'],
+            'start_date' => [
+                'required','date',
+                function ($attribute, $value, $fail) use ($request) {
+                    if (Carbon::parse($value)->lt(Carbon::today())) {
+                        $fail("The $attribute must be today or a future date.");
+                    }
+                    $endDate = $request->input('end_date');
+                    if ($endDate && Carbon::parse($value)->gt(Carbon::parse($endDate))) {
+                        $fail("The $attribute must be before or equal to the end date.");
+                    }
+                },
+            ],
+            'end_date' => [
+                'required','date',
+                function ($attribute, $value, $fail) use ($request) {
+                    $startDate = $request->input('start_date');
+                    if ($startDate && Carbon::parse($value)->lt(Carbon::parse($startDate))) {
+                        $fail("The $attribute must be after or equal to the start date.");
+                    }
+                },
+            ],
             'image'       => ['nullable','string'], // can switch to file upload later
             'location'    => ['required','string','max:255'],
-            'status'      => ['required','in:active,inactive,cancelled'],
+            'status'      => ['sometimes','in:active,inactive,cancelled'],
         ]);
 
-        $perahera = Perahera::create([
-            'user_id'     => $user->id,
-            ...$data
-        ]);
+        $perahera = Perahera::create(array_merge([
+            'user_id' => $user->id,
+        ], $data));
 
         return response()->json($perahera, 201);
     }
@@ -42,6 +68,7 @@ class PeraheraController extends Controller
     public function show(Perahera $perahera)
     {
         return $perahera->load('user');
+        
     }
 
     public function update(Request $request, Perahera $perahera)
@@ -59,10 +86,36 @@ class PeraheraController extends Controller
 
         $data = $request->validate([
             'name'        => ['sometimes','string','max:255'],
-            'description' => ['nullable','string'],
-            'start_date'  => ['sometimes','date'],
-            'end_date'    => ['sometimes','date','after_or_equal:start_date'],
-            'image'       => ['nullable','string'],
+            'description' => ['sometimes', 'nullable','string'],
+            'start_date' => [
+                'sometimes','date',
+                function ($attribute, $value, $fail) use ($request, $perahera) {
+                    $today = Carbon::today();
+                    $startDate = Carbon::parse($value);
+
+                    if ($startDate->lt($today)) {
+                        $fail("The $attribute must be today or a future date.");
+                    }
+
+                    $endDate = $request->input('end_date', $perahera->end_date);
+                    if ($endDate && $startDate->gt(Carbon::parse($endDate))) {
+                        $fail("The $attribute must be before or equal to the end date.");
+                    }
+                },
+            ],
+
+            'end_date' => [
+                'sometimes','date',
+                function ($attribute, $value, $fail) use ($request, $perahera) {
+                    $endDate = Carbon::parse($value);
+                    $startDate = $request->input('start_date', $perahera->start_date);
+
+                    if ($startDate && $endDate->lt(Carbon::parse($startDate))) {
+                        $fail("The $attribute must be after or equal to the start date.");
+                    }
+                },
+            ],
+            'image'       => ['sometimes', 'nullable','string'],
             'location'    => ['sometimes','string','max:255'],
             'status'      => ['sometimes','in:active,inactive,cancelled'],
         ]);

--- a/app/Http/Controllers/PeraheraController.php
+++ b/app/Http/Controllers/PeraheraController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Perahera;
+use Illuminate\Http\Request;
+
+class PeraheraController extends Controller
+{
+    public function index()
+    {
+        // anyone can view list of upcoming peraheras
+        return Perahera::with('user')->latest()->get();
+    }
+
+    public function store(Request $request)
+    {
+        $user = $request->user();
+
+        if (!in_array($user->user_type, ['admin', 'organizer'])) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        $data = $request->validate([
+            'name'        => ['required','string','max:255'],
+            'description' => ['nullable','string'],
+            'start_date'  => ['required','date'],
+            'end_date'    => ['required','date','after_or_equal:start_date'],
+            'image'       => ['nullable','string'], // can switch to file upload later
+            'location'    => ['required','string','max:255'],
+            'status'      => ['required','in:active,inactive,cancelled'],
+        ]);
+
+        $perahera = Perahera::create([
+            'user_id'     => $user->id,
+            ...$data
+        ]);
+
+        return response()->json($perahera, 201);
+    }
+
+    public function show(Perahera $perahera)
+    {
+        return $perahera->load('user');
+    }
+
+    public function update(Request $request, Perahera $perahera)
+    {
+        $user = $request->user();
+
+        if (!in_array($user->user_type, ['admin', 'organizer'])) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        // optional: ensure only the organizer or admin can edit
+        if ($user->user_type === 'organizer' && $perahera->user_id !== $user->id) {
+            return response()->json(['message' => 'You can only update your own events'], 403);
+        }
+
+        $data = $request->validate([
+            'name'        => ['sometimes','string','max:255'],
+            'description' => ['nullable','string'],
+            'start_date'  => ['sometimes','date'],
+            'end_date'    => ['sometimes','date','after_or_equal:start_date'],
+            'image'       => ['nullable','string'],
+            'location'    => ['sometimes','string','max:255'],
+            'status'      => ['sometimes','in:active,inactive,cancelled'],
+        ]);
+
+        $perahera->update($data);
+
+        return response()->json($perahera);
+    }
+
+    public function destroy(Request $request, Perahera $perahera)
+    {
+        $user = $request->user();
+
+        if (!in_array($user->user_type, ['admin', 'organizer'])) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        if ($user->user_type === 'organizer' && $perahera->user_id !== $user->id) {
+            return response()->json(['message' => 'You can only delete your own events'], 403);
+        }
+
+        $perahera->delete();
+
+        return response()->json(['message' => 'Perahera deleted']);
+    }
+}

--- a/app/Http/Resources/PeraheraResource.php
+++ b/app/Http/Resources/PeraheraResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PeraheraResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id'          => $this->id,
+            'name'        => $this->name,
+            'description' => $this->description,
+            'start_date'  => $this->start_date,
+            'end_date'    => $this->end_date,
+            'image'       => $this->image,
+            'location'    => $this->location,
+            'status'      => $this->status,
+            // only return limited user info
+            'organizer'   => [
+                'id'       => $this->user->id,
+                'username' => $this->user->username,
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/PeraheraResource.php
+++ b/app/Http/Resources/PeraheraResource.php
@@ -18,10 +18,13 @@ class PeraheraResource extends JsonResource
             'location'    => $this->location,
             'status'      => $this->status,
             // only return limited user info
-            'organizer'   => [
-                'id'       => $this->user->id,
-                'username' => $this->user->username,
-            ],
+            'organizer' => $this->whenLoaded('user', function () {
+                return [
+                    'id'       => $this->user->id,
+                    'username' => $this->user->username,
+                ];
+            }),
+
         ];
     }
 }

--- a/app/Models/Perahera.php
+++ b/app/Models/Perahera.php
@@ -7,9 +7,14 @@ use Illuminate\Database\Eloquent\Model;
 class Perahera extends Model
 {
     protected $fillable = [
-        'user_id', 'name', 'description',
+        'user_id', 'name', 'description', //have to keep user_id here otherwise it is like trying to make the user_id null which is not nullable. even though we manually assign user_id it always assigns the logged_in user_id.
         'start_date', 'end_date', 'image',
         'location', 'status'
+    ];
+
+    protected $casts = [
+        'start_date' => 'date',
+        'end_date'   => 'date',
     ];
 
     public function user()

--- a/app/Models/Perahera.php
+++ b/app/Models/Perahera.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Perahera extends Model
+{
+    protected $fillable = [
+        'user_id', 'name', 'description',
+        'start_date', 'end_date', 'image',
+        'location', 'status'
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_09_04_000018_create_peraheras_table.php
+++ b/database/migrations/2025_09_04_000018_create_peraheras_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('peraheras', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete(); // admin or organizer
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->string('image')->nullable(); // store URL or file path
+            $table->string('location');
+            $table->enum('status', ['active', 'inactive', 'cancelled'])->default('active');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('peraheras');
+    }
+};
+

--- a/database/migrations/2025_09_04_000018_create_peraheras_table.php
+++ b/database/migrations/2025_09_04_000018_create_peraheras_table.php
@@ -14,10 +14,11 @@ return new class extends Migration {
             $table->text('description')->nullable();
             $table->date('start_date');
             $table->date('end_date');
-            $table->string('image')->nullable(); // store URL or file path
+            $table->string('image', 2048)->nullable(); // store URL or file path
             $table->string('location');
             $table->enum('status', ['active', 'inactive', 'cancelled'])->default('active');
             $table->timestamps();
+            $table->index(['start_date', 'status']);
         });
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\ServiceController;
 use App\Http\Controllers\ServiceTypeController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PeraheraController;
 
 // Route::get('/user', function (Request $request) {
 //     return $request->user();
@@ -25,4 +26,13 @@ Route::middleware('auth:sanctum')->group(function () {
     
     Route::get('/services',  [ServiceController::class, 'index']);
     Route::post('/services', [ServiceController::class, 'store']);
+});
+
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('/peraheras', [PeraheraController::class, 'index']);
+    Route::post('/peraheras', [PeraheraController::class, 'store']);
+    Route::get('/peraheras/{perahera}', [PeraheraController::class, 'show']);
+    Route::put('/peraheras/{perahera}', [PeraheraController::class, 'update']);
+    Route::delete('/peraheras/{perahera}', [PeraheraController::class, 'destroy']);
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,10 +29,13 @@ Route::middleware('auth:sanctum')->group(function () {
 });
 
 
+// Public
+Route::get('/peraheras', [PeraheraController::class, 'index']);
+Route::get('/peraheras/{perahera}', [PeraheraController::class, 'show']);
+
+// Protected
 Route::middleware('auth:sanctum')->group(function () {
-    Route::get('/peraheras', [PeraheraController::class, 'index']);
     Route::post('/peraheras', [PeraheraController::class, 'store']);
-    Route::get('/peraheras/{perahera}', [PeraheraController::class, 'show']);
-    Route::put('/peraheras/{perahera}', [PeraheraController::class, 'update']);
+    Route::patch('/peraheras/{perahera}', [PeraheraController::class, 'update']);
     Route::delete('/peraheras/{perahera}', [PeraheraController::class, 'destroy']);
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public endpoints to list and view upcoming Perahera events (paginated, ordered by start date) including organizer info; authenticated endpoints to create, update, and delete events.
* **Bug Fixes / Validation**
  * Enforced comprehensive input validation and date rules (start/end constraints, today-or-future checks).
* **Permissions**
  * Role-based access: admins and organizers can manage events; organizers may only modify or delete their own.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->